### PR TITLE
Parameterize repo url and key

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,10 @@
 # defaults file for shibboleth-sp
 shib_config_dir:      "/etc/shibboleth"
 shib_hostname:           "{{ hostname | default('myapp') }}"
+# NOTE: apparently, in current versions of ansible (> 2.3.1, at least),
+# baseurl (the property for which this var is the value) can be a list
+# TODO: update ansible and test list value
+shib_repo_baseurl:    "http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/"
+shib_repo_gpgkey:     "http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/repodata/repomd.xml.key"
 
 apache_config_file:    "/etc/httpd/conf.d/01_{{ shib_hostname }}.conf"
-

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,8 +3,8 @@
   yum_repository:
     name: shibboleth
     description: "shibboleth repo"
-    baseurl: http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/
-    gpgkey: http://download.opensuse.org/repositories/security:/shibboleth/CentOS_7/repodata/repomd.xml.key
+    baseurl:  "{{ shib_repo_baseurl }}"
+    gpgkey:   "{{ shib_repo_gpgkey }}"
     gpgcheck: yes
     enabled: yes
   when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
Needed to implement fix for shib repo mirroring issue: https://github.com/jhu-sheridan-libraries/findit-ansible/issues/10